### PR TITLE
ci(gitlab): remove only changes

### DIFF
--- a/charts/certificate/.gitlab-ci.yml
+++ b/charts/certificate/.gitlab-ci.yml
@@ -4,9 +4,6 @@ Test socialgouv/certificate:
   stage: "Code Quality"
   environment:
     name: fabrique-dev
-  only:
-    changes:
-      - charts/certificate/**/*
   image: registry.gitlab.factory.social.gouv.fr/socialgouv/docker/helm:0.10.0
   script:
     - kubectl config set-context --current --namespace=default

--- a/charts/hpa/.gitlab-ci.yml
+++ b/charts/hpa/.gitlab-ci.yml
@@ -4,9 +4,6 @@ Test socialgouv/hpa:
   stage: "Code Quality"
   environment:
     name: fabrique-dev
-  only:
-    changes:
-      - charts/hpa/**/*
   image: registry.gitlab.factory.social.gouv.fr/socialgouv/docker/helm:0.18.0
   script:
     - kubectl config set-context --current --namespace=default

--- a/charts/nodejs/.gitlab-ci.yml
+++ b/charts/nodejs/.gitlab-ci.yml
@@ -4,9 +4,6 @@ Test socialgouv/nodejs:
   stage: "Code Quality"
   environment:
     name: fabrique-dev
-  only:
-    changes:
-      - charts/nodejs/**/*
   image: registry.gitlab.factory.social.gouv.fr/socialgouv/docker/helm:0.10.0
   script:
     - kubectl config set-context --current --namespace=default

--- a/plugins/just/.gitlab-ci.yml
+++ b/plugins/just/.gitlab-ci.yml
@@ -4,9 +4,6 @@ Test Just Plugin:
   stage: "Code Quality"
   environment:
     name: fabrique-dev
-  only:
-    changes:
-      - plugins/just/**/*
   image: registry.gitlab.factory.social.gouv.fr/socialgouv/docker/helm:0.11.1
   script:
     - sudo apk add --update shellcheck


### PR DESCRIPTION
<img src=https://media.giphy.com/media/8JKLu5GHXBvqg/giphy.gif width=693>


---

As our Gitlab does not support `only: refs: -merge_requests` ou `only: refs: -external_pull_requests` to ensure that our prs give use an accurate view of our merge request I would argue that it's better to remove this perf improvement.