### PR TITLE
fix: use real PG env var names and add PGSSLMODE

### DIFF
--- a/charts/managed-pg/values.yaml
+++ b/charts/managed-pg/values.yaml
@@ -24,22 +24,25 @@ db:
 ## jobs default env
 env:
   - name: PGSSLMODE
-    value: "require"
+    valueFrom:
+      secretKeyRef:
+        name: azure-pg-admin-user
+        key: PGSSLMODE
   - name: PGHOST
     valueFrom:
       secretKeyRef:
         name: azure-pg-admin-user
-        key: PG_HOST
+        key: PGHOST
   - name: PGUSER
     valueFrom:
       secretKeyRef:
         name: azure-pg-admin-user
-        key: ADMIN_PG_USER
+        key: PGUSER
   - name: PGPASSWORD
     valueFrom:
       secretKeyRef:
         name: azure-pg-admin-user
-        key: ADMIN_PG_PASSWORD
+        key: PGPASSWORD
 
 ## jobs restart policy
 restartPolicy: Never


### PR DESCRIPTION
As the secret name itself is already self-descriptive : `azure-pg-admin-user` and its the PG defaults